### PR TITLE
Updated for new structure of Node

### DIFF
--- a/src/Filters/PHPFilter.php
+++ b/src/Filters/PHPFilter.php
@@ -69,7 +69,7 @@ class PHPFilter extends Filter implements IFilter, NodeVisitor
     public function enterNode(Node $node)
     {
         $name = null;
-        if (($node instanceof Node\Expr\MethodCall || $node instanceof Node\Expr\StaticCall) && is_string($node->name)) {
+        if (($node instanceof \PhpParser\Node\Expr\MethodCall || $node instanceof \PhpParser\Node\Expr\StaticCall) && $node->name instanceof \PhpParser\Node\Identifier && is_string($node->name->name)) {
             $name = $node->name;
         } elseif ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
             $parts = $node->name->parts;


### PR DESCRIPTION
For functions like $this->translate, it is necessary to use FQDN of Class name and $node->name is class of Identifier with parameter $name of the name of function.